### PR TITLE
Fix control type change not correctly reflected in GUI

### DIFF
--- a/src/main/java/client/gui/ClientGUI.java
+++ b/src/main/java/client/gui/ClientGUI.java
@@ -728,7 +728,7 @@ public class ClientGUI {
 
 		JLabel selectControlType = new JLabel("Select Controls:");
 		JComboBox<String> controlTypeSelection = new JComboBox<>(new String[]{TANK_CONTROLS, SIMPLE_CONTROLS});
-		controlTypeSelection.setSelectedItem(TANK_CONTROLS);
+		controlTypeSelection.setSelectedItem(controlType);
 		controlTypeSelection.setMaximumSize(toggleReadyButton.getSize());
 		controlTypeSelection.addActionListener(e -> {
 			switch ((String) Objects.requireNonNull(controlTypeSelection.getSelectedItem())) {


### PR DESCRIPTION
Fixes the GUI always showing the control type as `Tank` even if it has been set to `Simple`.