### PR TITLE
chore: headless server handles null input instead of closing immediately

### DIFF
--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.2-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.5-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/src/main/java/server/lobby/ServerGUI.java
+++ b/src/main/java/server/lobby/ServerGUI.java
@@ -4,6 +4,9 @@ import shared.game.RaceTrack;
 
 import javax.swing.*;
 import java.awt.*;
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
 import java.util.NoSuchElementException;
 import java.util.Scanner;
 
@@ -101,17 +104,22 @@ public class ServerGUI {
 	public static void runServerConsole() {
 		addToConsole("Headless server ready! Type \"help\" for a list of commands.");
 
-		Scanner scan = new Scanner(System.in);
-		while (true) {
-			try {
-				String input = scan.nextLine();
-				if (parseInput(input))
+		try (BufferedReader reader = new BufferedReader(new InputStreamReader(System.in))) {
+			String input;
+			while (true) {
+				input = reader.readLine();
+				if (input == null) {
+					// Handle the null input case (e.g., CTRL-D) gracefully and continue the loop
+					continue;
+				}
+				if (parseInput(input)) {
 					break;
-			} catch (NoSuchElementException e) {
-				// CTRL-D detected
-				break;
+				}
 			}
+		} catch (IOException e) {
+			addToConsole("An error occurred while reading input: " + e.getMessage());
 		}
+
 		addToConsole("Exiting server...");
 		System.exit(0);
 	}


### PR DESCRIPTION
Running the jar using ProcessBuilder resulted in an immediate exit of the game. This was due to the fact that the Scanner in the headless server detected no input and therefore decided to exit.

Note: when a player exits their lobby, the server receives several NullPointerExceptions because player.getLobby() is null. The game still works though.

Note 2: the gradle version was changed to 8.5 to work with java 21, this mustn't stay as such